### PR TITLE
Buffer Pool Manager 3.0.0 complete.

### DIFF
--- a/buffer_pool_manager/read_guard.go
+++ b/buffer_pool_manager/read_guard.go
@@ -1,7 +1,5 @@
 package buffer_pool_manager
 
-import "errors"
-
 // ReadGuard is used to provide shared read access to a page stored in a frame in the buffer pool manager.
 type ReadGuard struct {
 	active     bool
@@ -25,14 +23,7 @@ func (bufferPool *SimpleBufferPoolManager) NewReadGuard(pageId PageID) (*ReadGua
 		return nil, err
 	}
 
-	versionCopy := page.version
-
 	page.mutex.RLock()
-
-	if page.version != versionCopy {
-		page.mutex.RUnlock()
-		return nil, errors.New("version mismatch error")
-	}
 
 	btreeNode := new(BTreeNode)
 	btreeNode.deserialize(page.data)
@@ -54,23 +45,8 @@ func (guard *ReadGuard) GetData() (*BTreeNode, bool) {
 	if !guard.active {
 		return nil, false
 	}
-	// if guard.btreeNode != nil {
-	// 	return guard.btreeNode, true
-	// }
-
-	// guard.btreeNode = new(BTreeNode)
-	// guard.btreeNode.deserialize(guard.page.data)
 
 	return guard.btreeNode, true
-}
-
-func (guard *ReadGuard) GetVersion() (int, bool) {
-
-	if !guard.active {
-		return -1, false
-	}
-
-	return guard.page.version, true
 }
 
 // Done is used to decrease the pin count of the page, and ensure the exclusive lock is released.

--- a/buffer_pool_manager/simple_buffer_pool_manager.go
+++ b/buffer_pool_manager/simple_buffer_pool_manager.go
@@ -64,9 +64,6 @@ type Frame struct {
 	// used to keep track of whether the data field has been written to since it was read from disk.
 	dirty bool
 
-	// used by the page guards to determine whether the page has been altered.
-	version int
-
 	// used to synchronize access to the page and its metadata stored in the frame.
 	mutex *sync.RWMutex
 }
@@ -237,7 +234,6 @@ func (bufferPool *SimpleBufferPoolManager) fetchPage(pageId PageID) (*Frame, err
 	frame.pinCount = 1
 	frame.pageId = pageId
 	frame.dirty = false
-	frame.version = 1
 
 	bufferPool.pageTable[pageId] = newFrameId
 
@@ -298,7 +294,6 @@ func (bufferPool *SimpleBufferPoolManager) deletePage(pageId PageID) (bool, erro
 
 	// 10. Reset dirty, version, pageId fields of the frame
 	frame.dirty = false
-	frame.version = 1
 	frame.pageId = 0
 	frame.pinCount = 0
 


### PR DESCRIPTION
Removed page versioning, will use crab latching for B-Tree traversal traversals and operations instead of 2 pass insertion. Seems easier.